### PR TITLE
update pull-defer to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "pull-stream": "~2.21.0",
     "pull-delayed-sink": "~1.0.0",
     "pull-reader": "~1.1.0",
-    "pull-defer": "~0.1.1",
+    "pull-defer": "~0.2.0",
     "pull-pushable": "~1.1.4",
     "pull-cat": "~1.1.7"
   },


### PR DESCRIPTION
Updating this dep will help `secret-handshake` pass its `npm ls` call, which is currently failing since shs uses 0.2.0, and this uses 0.1.x.
