### PR TITLE
fix: move pull-pair to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "pull-cat": "^1.1.9",
     "pull-defer": "^0.2.2",
     "pull-delayed-sink": "~1.0.0",
+    "pull-pair": "~1.0.0",
     "pull-pushable": "^2.0.0",
     "pull-reader": "^1.2.3",
     "pull-stream": "^3.2.0"
   },
   "devDependencies": {
     "pull-hang": "0.0.0",
-    "pull-pair": "~1.0.0",
     "tape": "~4.0.0"
   },
   "scripts": {


### PR DESCRIPTION
It's now used in the `index.js` and missing when installing it from npm.
